### PR TITLE
Create wedding invitation landing page with countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pınar & Ersan | Düğün Davetiyesi</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Montserrat:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="hero">
+    <div class="overlay"></div>
+    <section class="content">
+      <p class="subtitle">ÖZEL GÜNLER BİRLİKTE GÜZEL</p>
+      <h1 class="names">PINAR <span>&amp;</span> ERSAN</h1>
+      <p class="message">Hayatımızın en özel gününde sizleri de aramızda görmekten mutluluk duyarız.</p>
+
+      <div id="countdown" class="countdown" aria-label="Geri sayım">
+        <div><strong id="days">00</strong><small>GÜN</small></div>
+        <div><strong id="hours">00</strong><small>SAAT</small></div>
+        <div><strong id="minutes">00</strong><small>DAKİKA</small></div>
+        <div><strong id="seconds">00</strong><small>SANİYE</small></div>
+      </div>
+
+      <div class="details">
+        <p>📅 25 Temmuz 2026 &nbsp;|&nbsp; 🕖 19:00</p>
+        <p>📍 Happy Garden Düğün Salonu, Eskişehir</p>
+      </div>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,37 @@
+const targetDate = new Date('2026-07-25T19:00:00+03:00');
+
+const daysEl = document.getElementById('days');
+const hoursEl = document.getElementById('hours');
+const minutesEl = document.getElementById('minutes');
+const secondsEl = document.getElementById('seconds');
+
+function pad(value) {
+  return String(value).padStart(2, '0');
+}
+
+function updateCountdown() {
+  const now = new Date();
+  const diff = targetDate - now;
+
+  if (diff <= 0) {
+    daysEl.textContent = '00';
+    hoursEl.textContent = '00';
+    minutesEl.textContent = '00';
+    secondsEl.textContent = '00';
+    return;
+  }
+
+  const seconds = Math.floor(diff / 1000);
+  const days = Math.floor(seconds / (24 * 60 * 60));
+  const hours = Math.floor((seconds % (24 * 60 * 60)) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+
+  daysEl.textContent = pad(days);
+  hoursEl.textContent = pad(hours);
+  minutesEl.textContent = pad(minutes);
+  secondsEl.textContent = pad(secs);
+}
+
+updateCountdown();
+setInterval(updateCountdown, 1000);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,99 @@
+:root {
+  --gold: #d7bb84;
+  --white: #f7f2ea;
+  --shadow: rgba(0, 0, 0, 0.45);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: 'Montserrat', sans-serif;
+  color: var(--white);
+  background: #1d1a17;
+}
+
+.hero {
+  min-height: 100vh;
+  background-image: linear-gradient(rgba(28, 22, 14, 0.4), rgba(28, 22, 14, 0.6)),
+    url('https://images.unsplash.com/photo-1522673607200-164d1b6ce486?auto=format&fit=crop&w=1800&q=80');
+  background-size: cover;
+  background-position: center;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.content {
+  text-align: center;
+  max-width: 900px;
+  text-shadow: 0 10px 25px var(--shadow);
+}
+
+.subtitle {
+  letter-spacing: 0.35rem;
+  font-size: 0.95rem;
+  margin-bottom: 14px;
+}
+
+.names {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: clamp(3rem, 10vw, 7rem);
+  letter-spacing: 0.22rem;
+  margin: 0;
+  line-height: 1.03;
+}
+
+.names span {
+  display: block;
+  color: var(--gold);
+  font-size: 0.85em;
+  margin: 8px 0;
+}
+
+.message {
+  max-width: 700px;
+  margin: 18px auto 28px;
+  font-size: 1.12rem;
+  line-height: 1.6;
+}
+
+.countdown {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(90px, 130px));
+  justify-content: center;
+  gap: 14px;
+  margin: 10px 0 26px;
+}
+
+.countdown div {
+  border: 1px solid rgba(215, 187, 132, 0.8);
+  border-radius: 16px;
+  padding: 14px 10px;
+  background: rgba(42, 35, 24, 0.25);
+  backdrop-filter: blur(1.5px);
+}
+
+.countdown strong {
+  display: block;
+  font-size: 2rem;
+  font-family: 'Cormorant Garamond', serif;
+}
+
+.countdown small {
+  color: var(--gold);
+  letter-spacing: 0.14rem;
+  font-size: 0.76rem;
+}
+
+.details p {
+  margin: 8px 0;
+  font-size: 1rem;
+  letter-spacing: 0.06rem;
+}
+
+@media (max-width: 640px) {
+  .subtitle { letter-spacing: 0.2rem; }
+  .message { font-size: 1rem; }
+  .countdown { grid-template-columns: repeat(2, minmax(110px, 1fr)); }
+}


### PR DESCRIPTION
### Motivation
- Provide a single-page digital wedding invitation using the provided reference style and image assets with the couple and event details prefilled. 
- Include a live, decreasing countdown to the event so visitors can see time remaining until the ceremony.

### Description
- Added `index.html` containing the invitation structure and event text for `Pınar & Ersan` with date `25 Temmuz 2026` and venue `Happy Garden Düğün Salonu, Eskişehir`.
- Added `styles.css` with a romantic/glassmorphism-inspired theme, responsive layout, Google fonts, and a decorative background image.
- Added `script.js` implementing a live countdown targeting `2026-07-25T19:00:00+03:00` and updating days/hours/minutes/seconds every second.

### Testing
- Served the site locally with `python -m http.server 8000` and confirmed `curl -I http://127.0.0.1:8000/index.html` returned HTTP 200, indicating the page is reachable.
- Attempted an automated headless screenshot check (`which chromium-browser || which chromium || which google-chrome || which wkhtmltoimage`) but no suitable browser/tool was available in the environment, so screenshots were not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9920830c832cbc2cc4e7bd71bc36)